### PR TITLE
create action to push to quay.io

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,37 @@
+name: Build and Push mariadb
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: mariadb-build
+    runs-on: ubuntu-latest
+
+    steps:
+    
+      - name: Check Out Repo 
+        uses: actions/checkout@v2
+
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.REGISTRY_NAME }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: Dockerfile
+          push: true
+          tags: ${{ secrets.REGISTRY_NAME }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}, ${{ secrets.REGISTRY_NAME }}/${{ secrets.IMAGE_NAME }}:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
The Github action should:
- on every commit create a new docker image
- it will push it to a docker registry , (tested it against quay.io)
- following secrets need to be setup first in settings/secrets
-         REGISTRY_NAME: quay.io/username
          REGISTRY_USERNAME: username
          REGISTRY_PASSWORD: 
          IMAGE_NAME: mariadb
- The action will also tag the latest build with the tag "latest" and the commit tag e.g 5a70d2234f21a50a53331b5a7a48a1f24bbfafec , this way it will be easy to track which commit corresponds to the particular version of the image. 



